### PR TITLE
updated to openssl-1.0.2j

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -5,8 +5,8 @@
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://openssl.org/source/openssl-1.0.2h.tar.gz',
-        'sha1'  : '577585f5f5d299c44dd3c993d3c0ac7a219e4949',
+        'url'   : 'https://www.openssl.org/source/openssl-1.0.2j.tar.gz',
+        'sha1'  : 'bdfbdb416942f666865fa48fe13c2d0e588df54f',
         'target': {
             'mingw-w64': {
                 'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],


### PR DESCRIPTION
updated to https://www.openssl.org/source/openssl-1.0.2j.tar.gz
5183  	2016-Sep-26 10:04:14  	openssl-1.0.2j.tar.gz (SHA256) (PGP sign) (SHA1)
with hash from https://www.openssl.org/source/openssl-1.0.2j.tar.gz.sha1