### PR TITLE
cmake and appveyor config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,102 @@
+cmake_minimum_required (VERSION 2.8)
+
+set (CMAKE_SYSTEM_NAME Windows)
+
+if (MINGW)
+    set (CMAKE_SYSROOT "$ENV{HOME}/bin/cross")
+
+    set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM  NEVER)
+    set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY  ONLY)
+    set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE  ONLY)
+
+    set (toolchain_prefix   i686-w64-mingw32)
+
+    set (CMAKE_C_COMPILER   ${CMAKE_SYSROOT}/bin/${toolchain_prefix}-gcc)
+    set (CMAKE_CXX_COMPILER ${CMAKE_SYSROOT}/bin/${toolchain_prefix}-g++)
+    set (CMAKE_RC_COMPILER  ${CMAKE_SYSROOT}/bin/${toolchain_prefix}-windres)
+
+    set (win32_inc_dir ${CMAKE_SYSROOT}/${toolchain_prefix}/include)
+    set (win32_lib_dir ${CMAKE_SYSROOT}/${toolchain_prefix}/lib)
+endif (MINGW)
+
+project (NppFTP)
+
+if (MINGW)
+    set (defs
+        -DUNICODE -D_UNICODE -DMINGW_HAS_SECURE_API=1 -D_WIN32 -DWIN32
+        -D_WIN32_WINNT=0x0501 -DWIN32_LEAN_AND_MEAN -DNOCOMM -DLIBSSH_STATIC
+    )
+
+    set (CMAKE_CXX_FLAGS
+        "-std=c++11 -O3 -mwindows -mthreads -municode -Wall -Wno-unknown-pragmas"
+    )
+
+    set (CMAKE_MODULE_LINKER_FLAGS
+        "-s"
+    )
+else (MINGW)
+    set (defs
+        -DUNICODE -D_UNICODE -D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES -D_CRT_SECURE_NO_WARNINGS -D_WIN32 -DWIN32
+        -D_WIN32_WINNT=0x0501 -DWIN32_LEAN_AND_MEAN -DNOCOMM -DLIBSSH_STATIC
+    )
+
+    set (CMAKE_CXX_FLAGS
+        "/EHsc /MP /W4"
+    )
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+endif (MINGW)
+
+set (project_rc_files
+    src/Windows/NppFTP.rc
+)
+
+file(GLOB ftp_sources
+    "src/*.h"
+    "src/*.cpp"
+    "src/Windows/*.h"
+    "src/Windows/*.cpp"
+)
+
+file(GLOB tinyxml_sources
+    "tinyxml/include/*.h"
+    "tinyxml/src/*.cpp"
+)
+
+
+file(GLOB UTCP_sources
+    "UTCP/include/*.h"
+    "UTCP/src/*.cpp"
+)
+
+set (project_sources
+    ${ftp_sources}
+    ${tinyxml_sources}
+    ${UTCP_sources}
+)
+
+include_directories (/)
+include_directories (src/)
+include_directories (src/Windows/)
+include_directories (tinyxml/include/)
+include_directories (UTCP/include/)
+
+#3rdparty stuff
+include_directories (3rdparty/include/)
+include_directories (3rdparty/include/libssh/)
+include_directories (3rdparty/include/openssl/)
+
+link_directories(${CMAKE_SOURCE_DIR}/3rdparty/lib/)
+
+add_definitions (${defs})
+
+add_library (NppFTP MODULE ${project_rc_files} ${project_sources})
+
+if (MINGW)
+
+    include_directories (${win32_inc_dir})
+
+    target_link_libraries (NppFTP comctl32 Shlwapi ws2_32 ssh libeay32 ssleay32 z)
+else (MINGW)
+    target_link_libraries (NppFTP comctl32 Shlwapi ws2_32 ssh libeay32 ssleay32 zlib )
+endif (MINGW)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,80 @@
+version: 0.26.6.{build}
+image: Visual Studio 2015
+
+
+environment:
+  matrix:
+    - PlatformToolset: v140_xp
+    #- PlatformToolset: v120_xp
+    #- PlatformToolset: mingw-w64
+
+
+platform:
+    #- x64
+    - Win32
+
+configuration:
+    - Release
+    #- Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="Win32" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+    - ps: |
+        if ($env:PLATFORMTOOLSET -match "mingw-w64") {
+          $env:Path += ";C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin"
+          $env:Path += ";C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\i686-w64-mingw32\lib"
+          $env:Path = $env:Path.Replace('C:\Program Files\Git\usr\bin;','')
+          g++ --version
+          mingw32-make --version
+        }
+build:
+    verbosity: minimal
+
+before_build:
+- ps: |
+    Write-Output "Configuration: $env:CONFIGURATION"
+    Write-Output "Platform: $env:PLATFORM"
+    $generator = switch ($env:PLATFORMTOOLSET)
+    {
+        "v140_xp" {"Visual Studio 14 2015"}
+        "v120_xp" {"Visual Studio 12 2013"}
+        "mingw-w64" { "MinGW Makefiles"}
+    }
+    #not applicable with MinGW Makefiles generator
+    if ($env:PLATFORM -eq "x64" -and $env:PLATFORMTOOLSET -notmatch "mingw-w64")
+    {
+        $generator = "$generator Win64"
+    }
+    #cmake build type, depended on the used generator, see https://cmake.org/cmake/help/v3.6/variable/CMAKE_BUILD_TYPE.html#variable:CMAKE_BUILD_TYPE
+    if ($env:PLATFORMTOOLSET -match "mingw-w64")
+    {
+        $build_type = "-DCMAKE_BUILD_TYPE=$env:CONFIGURATION"
+        $build_config = ""
+    }
+    else
+    {
+        #seems vs build always needs also the debug config, choose via the config option to the build command
+        $build_type = "-DCMAKE_CONFIGURATION_TYPES=""Debug;Release"" "
+        $build_config = "--config $env:CONFIGURATION"
+    }
+    Write-Output "build_type: $build_type"
+    Write-Output "build_config: $build_config"
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    # Python 3 needed for urllib.request
+    - C:\Python34-x64\python build_3rdparty.py
+    - mkdir _build
+    - cd _build
+
+    - ps: |
+        cmake -G "$generator" $build_type ..
+        if ($LastExitCode -ne 0) {
+            throw "Exec: $ErrorMessage"
+        }
+        & cmake --build . --config $env:CONFIGURATION
+        if ($LastExitCode -ne 0) {
+            throw "Exec: $ErrorMessage"
+        }

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -18,7 +18,7 @@ DEPENDENT_LIBS = {
             'msvc': {
                 'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-asm VC-WIN32',
+                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN32',
                     'ms\\do_ms.bat',
                     'nmake /f ms\\nt.mak install'
                 ]

--- a/src/StdInc.h
+++ b/src/StdInc.h
@@ -21,6 +21,7 @@
 #define _WIN32_WINNT 0x0501
 #include <winsock2.h>
 #include <windows.h>
+#include <shellapi.h>
 #include <shlwapi.h>
 #include <tchar.h>
 #include <uxtheme.h>


### PR DESCRIPTION
- version with build of 3rd party libs under msvc on appveyor CI, see https://ci.appveyor.com/project/chcg/nppftp, you need to register this github project at appveyor to enable it for their CI builds
- cmake config for nppftp code itself
- added include for shellapi.h, not included if WIN32_LEAN_AND_MEAN is defined, like done for optimization purposes in cmake config file
- added no-shared also for msvc openssl build

Some open issue:
- the changes at StdInc.h and build_3rdparty.py  are not really necessary and I could remove them, if you done like them
- appveyor config doesn't work for mingw-w64, seems build_3rdparty.py is not prepared to run mingw-w64 on windows and appveyor has in the current config no unix make in the path, therefore it is switched off currently
- build_3rdparty.py is not prepared for debug builds. Is this intentional?
- build_3rdparty.py is not prepared for msvc x64 and mingw-w64 x86_64
- appveyor config would mixes the platform toolset between 3rd party libs and nppftp, therefore v120_xp is switched off currently
- appveyor has from time to time problems with the download, I didn't see this issues on using git submodules, did some tests\adaptations on submodule usage in https://github.com/chcg/NppFTP/tree/appveyor

