### PR TITLE
Added 64-bit build scripts

### DIFF
--- a/Makefile64.mingw
+++ b/Makefile64.mingw
@@ -1,0 +1,84 @@
+# Makefile for building NppFTP
+
+ifeq ($(OS),Windows_NT)
+WINDRES = windres
+RMDIR   = if exist $(1) rd /s /q $(1)
+else
+WINDRES = x86_64-w64-mingw32-windres
+RMDIR   = rm -fr $(1)
+endif
+
+CXX    = x86_64-w64-mingw32-g++
+CFLAGS = -MMD -Os -O3 -Werror -fexpensive-optimizations -DLIBSSH_STATIC -DUNICODE -D_UNICODE
+LFLAGS = -static -Lobj -L3rdparty/lib -lcomdlg32 -lcomctl32 -luuid -lole32 -lshlwapi -lssh -lssl -lcrypto -lz -lgdi32 -lws2_32
+INC    = -I3rdparty/include -Isrc -Isrc/Windows -Itinyxml/include -IUTCP/include -I.
+RES    = obj/NppFTP.res
+
+TGT    = bin/NppFTP.dll
+TXML_OBJ = $(patsubst tinyxml/src/%.cpp,obj/%.o,$(wildcard tinyxml/src/*.cpp))
+UTCP_OBJ = $(patsubst UTCP/src/%.cpp,obj/%.o,$(wildcard UTCP/src/*.cpp))
+NPP_OBJ  = $(patsubst src/%.cpp,obj/%.o,$(wildcard src/*.cpp)) $(patsubst src/Windows/%.cpp,obj/%.o,$(wildcard src/Windows/*.cpp))
+OBJECTS  = $(TXML_OBJ) $(UTCP_OBJ) $(NPP_OBJ)
+DEPENDS  = ${OBJECTS:.o=.d}
+
+TGT_D      = bin/NppFTPd.dll
+TXML_OBJ_D = $(patsubst tinyxml/src/%.cpp,obj/%_debug.o,$(wildcard tinyxml/src/*.cpp))
+UTCP_OBJ_D = $(patsubst UTCP/src/%.cpp,obj/%_debug.o,$(wildcard UTCP/src/*.cpp))
+NPP_OBJ_D  = $(patsubst src/%.cpp,obj/%_debug.o,$(wildcard src/*.cpp)) $(patsubst src/Windows/%.cpp,obj/%_debug.o,$(wildcard src/Windows/*.cpp))
+OBJECTS_D  = $(TXML_OBJ_D) $(UTCP_OBJ_D) $(NPP_OBJ_D)
+DEPENDS_D  = ${OBJECTS_D:.o=.d}
+
+all:     release
+debug:   bin obj $(TGT_D)
+release: bin obj $(TGT)
+	@echo ============ creating NppFTP.zip ============
+	@zip -9 -r NppFTP.zip $(TGT) doc/
+test:    bin obj $(TGT)
+	@copy /y $(TGT) "%APPDATA%\Notepad++\plugins" >nul
+	@cmd /c start notepad++
+
+obj/%.o: tinyxml/src/%.cpp
+	@echo CXX  $< & $(CXX) -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%.o: UTCP/src/%.cpp
+	@echo CXX  $< & $(CXX) -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%.o: src/%.cpp
+	@echo CXX  $< & $(CXX) -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%.o: src/Windows/%.cpp
+	@echo CXX  $< & $(CXX) -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%_debug.o: tinyxml/src/%.cpp
+	@echo CXX  $< & $(CXX) -g -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%_debug.o: UTCP/src/%.cpp
+	@echo CXX  $< & $(CXX) -g -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%_debug.o: src/%.cpp
+	@echo CXX  $< & $(CXX) -g -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%_debug.o: src/Windows/%.cpp
+	@echo CXX  $< & $(CXX) -g -c $(CFLAGS) $(INC) $< -o $@
+
+obj/%.res: src/Windows/%.rc
+	@echo RES  $< & $(WINDRES) $(INC) -J rc -O coff -i $< -o $@
+
+$(TGT): $(OBJECTS) $(RES)
+	@echo LINK $@ & $(CXX) -shared -Wl,--dll $(OBJECTS) $(RES) -o $@ -s $(LFLAGS)
+
+$(TGT_D): $(OBJECTS_D) $(RES)
+	@echo LINK $@ & $(CXX) -shared -Wl,--dll $(OBJECTS_D) $(RES) -o $@ $(LFLAGS)
+
+bin:
+	@mkdir bin
+
+obj:
+	@mkdir obj
+
+clean:
+	@$(call RMDIR, bin)
+	@$(call RMDIR, obj)
+
+-include ${DEPENDS}
+-include ${DEPENDS_D}

--- a/Makefile64.mingw
+++ b/Makefile64.mingw
@@ -9,7 +9,7 @@ RMDIR   = rm -fr $(1)
 endif
 
 CXX    = x86_64-w64-mingw32-g++
-CFLAGS = -MMD -Os -O3 -Werror -fexpensive-optimizations -DLIBSSH_STATIC -DUNICODE -D_UNICODE
+CFLAGS = -MMD -Os -O3 -Wall -Werror -fexpensive-optimizations -DLIBSSH_STATIC -DUNICODE -D_UNICODE
 LFLAGS = -static -Lobj -L3rdparty/lib -lcomdlg32 -lcomctl32 -luuid -lole32 -lshlwapi -lssh -lssl -lcrypto -lz -lgdi32 -lws2_32
 INC    = -I3rdparty/include -Isrc -Isrc/Windows -Itinyxml/include -IUTCP/include -I.
 RES    = obj/NppFTP.res

--- a/UTCP/include/uh_ctrl.h
+++ b/UTCP/include/uh_ctrl.h
@@ -103,7 +103,7 @@ protected:
     void OnPaint();
     void OnSize();
 
-    static long CALLBACK WndProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam);
+    static long long CALLBACK WndProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam);
 
     void OnHScroll(int code,int pos);
     void OnVScroll(int code,int pos);

--- a/UTCP/src/uh_ctrl.cpp
+++ b/UTCP/src/uh_ctrl.cpp
@@ -242,7 +242,7 @@ Params
 Return
     n/a
 ***********************************/
-long CALLBACK CUH_Control::WndProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam){
+long long CALLBACK CUH_Control::WndProc(HWND hwnd,UINT message,WPARAM wParam,LPARAM lParam){
 
     switch(message){
         case WM_NCCREATE:{

--- a/build_3rdparty_64bit.py
+++ b/build_3rdparty_64bit.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+# --------------------------------------------------------------- CONFIGURATION
+
+DEPENDENT_LIBS = {
+    'openssl': {
+        'order' : 1,
+        'url'   : 'https://www.openssl.org/source/openssl-1.0.2j.tar.gz',
+        'sha1'  : 'bdfbdb416942f666865fa48fe13c2d0e588df54f',
+        'target': {
+            'mingw-w64': {
+                'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],
+                'commands': [
+                    'perl Configure --openssldir=%(dest)s --cross-compile-prefix=x86_64-w64-mingw32- no-shared no-asm mingw64',
+                    'make depend', 'make', 'make install_sw'
+                ]
+            },
+            'msvc': {
+                'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
+                'commands': [
+                    'perl Configure --openssldir=%(dest)s no-asm VC-WIN32',
+                    'ms\\do_ms.bat',
+                    'nmake /f ms\\nt.mak install'
+                ]
+            }
+        }
+    },
+
+    'zlib': {
+        'order' : 2,
+        'url'   : 'http://downloads.sourceforge.net/libpng/zlib-1.2.8.tar.gz',
+        'sha1'  : 'a4d316c404ff54ca545ea71a27af7dbc29817088',
+        'target': {
+            'mingw-w64': {
+                'result':   ['include/zlib.h', 'include/zconf.h', 'lib/libz.a'],
+                'commands': [
+                    'make -f win32/Makefile.gcc PREFIX=x86_64-w64-mingw32-',
+                    'cp zlib.h zconf.h %(dest)s/include',
+                    'cp libz.a %(dest)s/lib'
+                ]
+            },
+            'msvc': {
+                'result':   ['include/zlib.h', 'include/zconf.h', 'lib/zlib.lib'],
+                'replace':  [('win32/Makefile.msc', '-MD', '-MT')],
+                'commands': [
+                    'nmake /f win32/Makefile.msc zlib.lib',
+                    'copy /Y zlib.h   %(dest)s\\include >nul',
+                    'copy /Y zconf.h  %(dest)s\\include >nul',
+                    'copy /Y zlib.lib %(dest)s\\lib     >nul'
+                ]
+            }
+        }
+    },
+
+    'libssh': {
+        'order' : 3,
+        'shadow': True,
+        'url'   : 'https://red.libssh.org/attachments/download/195/libssh-0.7.3.tar.xz',
+        'sha1'  : '9de2a8fde51aa7b7855008fafd5bf47ebb01289f',
+        'target': {
+            'mingw-w64': {
+                'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],
+                'commands': [
+                    'cmake -DCMAKE_SYSTEM_NAME=Windows \
+                        -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s/include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s/lib/libcrypto.a \
+                        -DWITH_STATIC_LIB=ON -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
+                    'make',
+                    'make install'
+                ]
+            },
+            'msvc': {
+                'result':   ['include/libssh/libssh.h', 'lib/ssh.lib'],
+                'commands': [
+                    'cmake -G "NMake Makefiles" -DWITH_STATIC_LIB=ON -DCMAKE_BUILD_TYPE=Release \
+                        "-DCMAKE_C_FLAGS_RELEASE=/MT /O2 /Ob2 /D NDEBUG" "-DCMAKE_CXX_FLAGS_RELEASE=/MT /O2 /Ob2 /D NDEBUG" \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libeay32.lib \
+                        -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
+                    'nmake install',
+                    'del %(dest)s\\lib\\ssh.lib >nul',
+                    'move %(dest)s\\lib\\static\\ssh.lib %(dest)s\\lib >nul'
+                ]
+            }
+
+        }
+    }
+}
+
+# --------------------------------------------------------------- HELPERS
+
+import os, sys, platform, shutil, urllib.request, hashlib, tarfile
+
+def join_path(*p):
+    return os.path.abspath(os.path.join(*p))
+
+def message(msg):
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+def error(msg):
+    message(msg+'\n')
+    sys.exit(1)
+
+def shell(cmd):
+    ret = os.system(cmd)
+    if ret != 0:
+        error("%s\ncommand failed: exit code %d" % (cmd, ret))
+
+def rmdir(path):
+    if os.path.exists(path):
+        if platform.system() == 'Windows':
+            shell('attrib -R %s\* /S' % path)
+        shutil.rmtree(path)
+
+def mkdir_p(*paths):
+    path = join_path(*paths)
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+def download_file(url, sha1, dir):
+    name = url.split('/')[-1]
+    loc  = join_path(dir, name)
+    if os.path.exists(loc):
+        hash = hashlib.sha1(open(loc, 'rb').read()).hexdigest()
+        if hash == sha1:
+            return loc
+        os.remove(loc)
+        message('Checksum mismatch for %s, re-downloading.\n' % name)
+    def hook(cnt, bs, total):
+        pct = int(cnt*bs*100/total)
+        message("\rDownloading: %s [%d%%]" % (name, pct))
+    urllib.request.urlretrieve(url, loc, reporthook=hook)
+    message("\r")
+    hash = hashlib.sha1(open(loc, 'rb').read()).hexdigest()
+    if hash != sha1:
+        os.remove(loc)
+        error('Checksum mismatch for %s, aborting.' % name)
+    message("\rDownloaded: %s [checksum OK]\n" % name)
+    return loc
+
+def download_tarball(url, sha1, dir, name):
+    loc = download_file(url, sha1, dir)
+    tar = tarfile.open(loc)
+    sub = tar.getnames()[0]
+    if '/' in sub:
+        sub = sub[:sub.index('/')]
+    src = join_path(dir, sub)
+    tgt = join_path(dir, name)
+    rmdir(src)
+    tar.extractall(dir)
+    rmdir(tgt)
+    os.rename(src, tgt)
+    return tgt
+
+# --------------------------------------------------------------- BUILDING
+
+def main():
+    build = os.path.abspath('obj')
+    dest  = os.path.abspath('3rdparty')
+    mkdir_p(build)
+    mkdir_p(dest, 'include')
+    mkdir_p(dest, 'lib')
+
+    target = platform.system() == 'Windows' and 'msvc' or 'mingw-w64'
+    for library in sorted(DEPENDENT_LIBS, key=lambda x: DEPENDENT_LIBS[x]['order']):
+        if target not in DEPENDENT_LIBS[library]['target']:
+            print('%s: skipping (not available)' % library)
+            continue
+
+        cfg = DEPENDENT_LIBS[library]['target'][target]
+        built = True
+        for path in cfg['result']:
+            built = built and os.path.exists(join_path(dest, path))
+        if built:
+            print('%s: skipping (already built)' % library)
+            continue
+        print('-' * 60, library)
+        download_tarball(DEPENDENT_LIBS[library]['url'],
+                         DEPENDENT_LIBS[library]['sha1'], build, library)
+
+        if DEPENDENT_LIBS[library].get('shadow'):
+            rmdir(join_path(build, library+'-build'))
+            mkdir_p(join_path(build, library+'-build'))
+            os.chdir(join_path(build, library+'-build'))
+        else:
+            os.chdir(join_path(build, library))
+
+        for location, src, tgt in cfg.get('replace', []):
+            data = open(join_path(build, library, location), 'r').read()
+            open(join_path(build, library, location), 'w').write(data.replace(src, tgt))
+
+        for cmd in cfg['commands']:
+            shell(cmd % { 'dest' : dest, 'src': join_path(build, library) })
+        os.chdir(dest)
+        for path in cfg['result']:
+            if not os.path.exists(path):
+                error('Unable to build %s, missing: %s' % (library, path))
+
+if __name__ == '__main__':
+    main()

--- a/src/Windows/KBIntDialog.cpp
+++ b/src/Windows/KBIntDialog.cpp
@@ -100,12 +100,12 @@ INT_PTR KBIntDialog::OnInitDialog() {
 			::CreateWindowEx(0, WC_EDIT, TEXT(""),
 							WS_CHILD | WS_VSCROLL | ES_AUTOHSCROLL | ES_MULTILINE | ES_READONLY | WS_VISIBLE,
 							promptRect.left, promptRect.top, promptRect.right-promptRect.left, promptRect.bottom-promptRect.top,
-							m_hwnd, (HMENU)curPromptID, m_hInstance, NULL);
+							m_hwnd, (HMENU)(INT_PTR)curPromptID, m_hInstance, NULL);
 
 			::CreateWindowEx(WS_EX_CLIENTEDGE, WC_EDIT, TEXT(""),
 							WS_CHILD | WS_BORDER | ES_AUTOHSCROLL | WS_VISIBLE,
 							answerRect.left, answerRect.top, answerRect.right-answerRect.left, answerRect.bottom-answerRect.top,
-							m_hwnd, (HMENU)curPromptID, m_hInstance, NULL);
+							m_hwnd, (HMENU)(INT_PTR)curPromptID, m_hInstance, NULL);
 		}
 
 		int totalDeltaY = deltaY * (m_nrPrompt-1);


### PR DESCRIPTION
Added two build files for 64-bit. Tested only with Linux mingw64 compilers.

Modified uh_ctrl to reference long long for HWND pointers.

Changed the Makefile64.mingw file to remove -Wall as it threw errors on calling functions with return values that were unused.