### PR TITLE
cmake mingw build for travis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,139 @@
+cmake_minimum_required (VERSION 2.8)
+
+set (CMAKE_SYSTEM_NAME Windows)
+
+if (MINGW)
+    set (CMAKE_SYSROOT "$ENV{HOME}/bin/cross")
+
+    set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM  NEVER)
+    set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY  ONLY)
+    set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE  ONLY)
+
+    set (toolchain_prefix   i686-w64-mingw32)
+
+    set (CMAKE_C_COMPILER   ${CMAKE_SYSROOT}/bin/${toolchain_prefix}-gcc)
+    set (CMAKE_CXX_COMPILER ${CMAKE_SYSROOT}/bin/${toolchain_prefix}-g++)
+    set (CMAKE_RC_COMPILER  ${CMAKE_SYSROOT}/bin/${toolchain_prefix}-windres)
+
+    set (win32_inc_dir ${CMAKE_SYSROOT}/${toolchain_prefix}/include)
+    set (win32_lib_dir ${CMAKE_SYSROOT}/${toolchain_prefix}/lib)
+endif (MINGW)
+
+# needed to build 3rdparty libs via python script
+set(Python_ADDITIONAL_VERSIONS 3)
+find_package(PythonInterp 3)
+if( NOT PYTHONINTERP_FOUND )
+  message(FATAL_ERROR
+"Unable to find Python interpreter, required for builds and testing.
+
+Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
+endif()
+
+if( ${PYTHON_VERSION_STRING} VERSION_LESS 3 )
+  message(FATAL_ERROR "Python 3 or newer is required")
+endif()
+
+# needed to build 3rdparty lib openssl
+find_package(Perl)
+
+project (NppFTP)
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+set (output_dir "x64")
+set (3rdparty_prefix "x86_64-w64-mingw32")
+else()
+set (output_dir "x86")
+set (3rdparty_prefix "i686-w64-mingw32")
+endif()
+
+#check if ExternalProject_Add could be used as replacement of the python script
+#this would remove the dependency to python
+add_custom_target(
+    NppFTP3rdPartyPrerequists
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build_3rdparty.py ${output_dir} ${3rdparty_prefix}
+    )
+
+if (MINGW)
+    set (defs
+        -DUNICODE -D_UNICODE -DMINGW_HAS_SECURE_API=1 -D_WIN32 -DWIN32
+        -D_WIN32_WINNT=0x0501 -DWIN32_LEAN_AND_MEAN -DNOCOMM -DLIBSSH_STATIC
+    )
+
+    set (CMAKE_CXX_FLAGS
+        "-std=c++11 -O3 -mwindows -mthreads -municode -Wall -Wno-unknown-pragmas"
+    )
+
+    set (CMAKE_MODULE_LINKER_FLAGS
+        "-s -static"
+    )
+endif (MINGW)
+
+set (project_rc_files
+    src/Windows/NppFTP.rc
+)
+
+file(GLOB ftp_sources
+    "src/*.h"
+    "src/*.cpp"
+    "src/Windows/*.h"
+    "src/Windows/*.cpp"
+)
+
+file(GLOB tinyxml_sources
+    "tinyxml/include/*.h"
+    "tinyxml/src/*.cpp"
+)
+
+
+file(GLOB UTCP_sources
+    "UTCP/include/*.h"
+    "UTCP/src/*.cpp"
+)
+
+set (project_sources
+    ${ftp_sources}
+    ${tinyxml_sources}
+    ${UTCP_sources}
+)
+
+include_directories (${CMAKE_SOURCE_DIR}/)
+include_directories (${CMAKE_SOURCE_DIR}/src/)
+include_directories (${CMAKE_SOURCE_DIR}/src/Windows/)
+include_directories (${CMAKE_SOURCE_DIR}/tinyxml/include/)
+include_directories (${CMAKE_SOURCE_DIR}/UTCP/include/)
+
+#3rdparty stuff
+include_directories (${CMAKE_BINARY_DIR}/${output_dir}/3rdparty/include/)
+include_directories (${CMAKE_BINARY_DIR}/${output_dir}/3rdparty/include/libssh/)
+include_directories (${CMAKE_BINARY_DIR}/${output_dir}/3rdparty/include/openssl/)
+
+link_directories(${CMAKE_BINARY_DIR}/${output_dir}/3rdparty/lib/)
+
+add_definitions (${defs})
+
+add_library (NppFTP MODULE ${project_rc_files} ${project_sources})
+
+add_dependencies(NppFTP NppFTP3rdPartyPrerequists)
+
+if (MINGW)
+
+    include_directories (${win32_inc_dir})
+    #remove the lib from the generated target lib
+    SET(CMAKE_SHARED_LIBRARY_PREFIX "")
+
+    target_link_libraries (NppFTP comctl32 shlwapi ssh ssl crypto z ws2_32)
+endif (MINGW)
+
+# build a CPack driven zip package
+#include (InstallRequiredSystemLibraries)
+
+install(TARGETS NppFTP 
+  DESTINATION ${CMAKE_BINARY_DIR}/zip/bin)
+
+FILE(GLOB files "${CMAKE_SOURCE_DIR}/doc/*")
+INSTALL(FILES ${files} DESTINATION ${CMAKE_BINARY_DIR}/zip/doc)
+
+
+set(CPACK_GENERATOR ZIP)
+
+INCLUDE(CPack)

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -18,7 +18,7 @@ DEPENDENT_LIBS = {
             'msvc': {
                 'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-asm VC-WIN32',
+                    'perl Configure --openssldir=%(dest)s  no-shared no-asm VC-WIN32',
                     'ms\\do_ms.bat',
                     'nmake /f ms\\nt.mak install'
                 ]
@@ -81,7 +81,6 @@ DEPENDENT_LIBS = {
                     'move %(dest)s\\lib\\static\\ssh.lib %(dest)s\\lib >nul'
                 ]
             }
-
         }
     }
 }


### PR DESCRIPTION
- intial cmake for mingw as future replacement of handwritten makefile
Known issues:
-- zip seems to be still an issue and filename is not correct right now
-- naming is still libNppFTP.dll

- avoid building unused shared dll for package openssl by config param no-shared also in win32