### PR TITLE
Improve Building doc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,8 +5,13 @@ process, and hence require a working internet connection.
 MinGW-w64
 ---------
 
-Cross-compiling from Ubuntu 16.04 "xenial":
-* Install the necessary packages: `sudo apt install -y python3 mingw-w64 cmake zip`.
-* Run `make -f Makefile.mingw BITS=32` to compile and produce the 32-bit plugin.
-  Alternatively, run `make -f Makefile.mingw BITS=64` to produce the 64-bit plugin.
-  If no value is specified for `BITS`, a 32-bit target is assumed.
+Cross-compiling from Linux has been tested with Debian/Ubuntu and Fedora. You will need to
+install the following packages:
+* **Common**: `python3 cmake zip`
+* **Debian/Ubuntu**: `mingw-w64`
+* **Fedora 32-bit target**: `mingw32-gcc-c++ mingw32-winpthreads-static`
+* **Fedora 64-bit target**: `mingw64-gcc-c++ mingw64-winpthreads-static`
+
+Then, run `make -f Makefile.mingw BITS=32` to compile and produce the 32-bit plugin.
+Alternatively, run `make -f Makefile.mingw BITS=64` to produce the 64-bit plugin.
+If no value is specified for `BITS`, a 32-bit target is assumed.


### PR DESCRIPTION
Add building instructions for developpers on fedora >= 25.
Indeed, steps are a little bit more complex than Ubuntu system.