### PR TITLE
Ensure ascii or bin types is not empty before access it

### DIFF
--- a/src/FTPProfile.cpp
+++ b/src/FTPProfile.cpp
@@ -510,14 +510,19 @@ const TCHAR* FTPProfile::GetBinaryType(int i) {
 
 Transfer_Mode FTPProfile::GetFileTransferMode(const TCHAR* file) const {
 	LPCTSTR suffix = NULL;
-	suffix = PathFindSuffixArray(file, (const TCHAR**)(&m_asciiTypes[0]), m_asciiTypes.size());
-	if (suffix) {
-		return Mode_ASCII;
+
+	if (m_asciiTypes.size()) {
+		suffix = PathFindSuffixArray(file, (const TCHAR**)(&m_asciiTypes[0]), m_asciiTypes.size());
+		if (suffix) {
+			return Mode_ASCII;
+		}
 	}
 
-	suffix = PathFindSuffixArray(file, (const TCHAR**)(&m_binTypes[0]), m_binTypes.size());
-	if (suffix) {
-		return Mode_Binary;
+	if (m_binTypes.size()) {
+		suffix = PathFindSuffixArray(file, (const TCHAR**)(&m_binTypes[0]), m_binTypes.size());
+		if (suffix) {
+			return Mode_Binary;
+		}
 	}
 
 	return m_transferMode;


### PR DESCRIPTION
Avoid errors with the Windows compiler and sanitize the code.