### PR TITLE
openssl-1.0.2m

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
         if ($LastExitCode -ne 0) {
             throw "Exec: $ErrorMessage"
         }
-        & cmake --build . --config $env:CONFIGURATION
+        & cmake --build . --config $env:CONFIGURATION -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
         if ($LastExitCode -ne 0) {
             throw "Exec: $ErrorMessage"
         }

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -5,8 +5,8 @@
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://www.openssl.org/source/openssl-1.0.2l.tar.gz',
-        'sha1'  : 'b58d5d0e9cea20e571d903aafa853e2ccd914138',
+        'url'   : 'https://www.openssl.org/source/openssl-1.0.2m.tar.gz',
+        'sha1'  : '27fb00641260f97eaa587eb2b80fab3647f6013b',
         'target': {
             'mingw-w64': {
                 'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],


### PR DESCRIPTION
- update to openssl-1.0.2m, with security fixes see https://www.opensslorg/news/cl102.txt

 Changes between 1.0.2l and 1.0.2m [2 Nov 2017]

  *) bn_sqrx8x_internal carry bug on x86_64

     There is a carry propagating bug in the x86_64 Montgomery squaring
     procedure. No EC algorithms are affected. Analysis suggests that attacks
     against RSA and DSA as a result of this defect would be very difficult to
     perform and are not believed likely. Attacks against DH are considered just
     feasible (although very difficult) because most of the work necessary to
     deduce information about a private key may be performed offline. The amount
     of resources required for such an attack would be very significant and
     likely only accessible to a limited number of attackers. An attacker would
     additionally need online access to an unpatched system using the target
     private key in a scenario with persistent DH parameters and a private
     key that is shared between multiple clients.

     This only affects processors that support the BMI1, BMI2 and ADX extensions
     like Intel Broadwell (5th generation) and later or AMD Ryzen.

     This issue was reported to OpenSSL by the OSS-Fuzz project.
     (CVE-2017-3736)
     [Andy Polyakov]

  *) Malformed X.509 IPAddressFamily could cause OOB read

     If an X.509 certificate has a malformed IPAddressFamily extension,
     OpenSSL could do a one-byte buffer overread. The most likely result
     would be an erroneous display of the certificate in text format.

     This issue was reported to OpenSSL by the OSS-Fuzz project.
     (CVE-2017-3735)
     [Rich Salz]
- appveyor output optimization