### PR TITLE
correct openssl 1.0.2n win32 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,16 @@ project (NppFTP)
 
 if (CMAKE_SIZEOF_VOID_P EQUAL 8)
 set (output_dir "x64")
-set (3rdparty_prefix "x86_64-w64-mingw32")
+    if (MINGW)
+        set (3rdparty_prefix "x86_64-w64-mingw32")
+    else()
+        set (3rdparty_prefix "msvc_x64")
+    endif()
 else()
 set (output_dir "x86")
-set (3rdparty_prefix "i686-w64-mingw32")
+    if (MINGW)
+        set (3rdparty_prefix "i686-w64-mingw32")
+    endif()
 endif()
 
 #check if ExternalProject_Add could be used as replacement of the python script

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -18,7 +18,7 @@ DEPENDENT_LIBS = {
             'msvc': {
                 'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN32',
+                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN32 -wd4005',
                     'ms\\do_ms.bat',
                     'nmake /f ms\\nt.mak install'
                 ]


### PR DESCRIPTION
- correct win32 x64 openssl build use correct config for build_3rdparty.py
- switch off openssl warnings about warning C4005: '__useHeader': macro redefinition and warning C4005: '__on_failure': macro redefinition
, see also https://github.com/openssl/openssl/issues/4987