### PR TITLE
Added auto-connect feature for easy remote work on startup and "multiple" connections

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -73,7 +73,7 @@ DEPENDENT_LIBS = {
     'libssh': {
         'order' : 3,
         'shadow': True,
-        'url'   : 'https://red.libssh.org/attachments/download/218/libssh-0.7.5.tar.xz',
+        'url'   : 'https://www.libssh.org/files/0.7/libssh-0.7.5.tar.xz',
         'sha1'  : '0cf54e96e91d73e730ae4bc76d3f5277100c0f1a',
         'target': {
             'mingw-w64': {

--- a/src/NppFTP.cpp
+++ b/src/NppFTP.cpp
@@ -166,9 +166,10 @@ int NppFTP::OnSave(const TCHAR* path) {
 
 	TCHAR username[FILENAME_MAX];	// assume username+path is smaller than largest allowed filename
 	TCHAR hostname[FILENAME_MAX];
-	GetUserAndHostFromFilename(path, username, hostname);	// username and hostname are SET inside this function
+	// username and hostname are SET inside this function
+	bool filenameHasHost = GetUserAndHostFromFilename(path, username, hostname);	
 
-	if (m_ftpSession->IsConnected())	// see if we're connected to the correct server for our file
+	if (filenameHasHost && m_ftpSession->IsConnected())	// see if we're connected to the correct server for our file
 	{
 		DisconnectOnInfoMismatch(username, hostname);	// if our info doesnt match current profile, we'll disconnect here
 	}

--- a/src/NppFTP.h
+++ b/src/NppFTP.h
@@ -44,6 +44,7 @@ public:
 private:
 	int						LoadSettings();		//-1 error, 0 success, 1 unable to load
 	int						SaveSettings();
+	void					AttemptToAutoConnect(const TCHAR* path);
 
 	FTPSettings*			m_ftpSettings;
 	FTPSession*				m_ftpSession;

--- a/src/NppFTP.h
+++ b/src/NppFTP.h
@@ -44,7 +44,9 @@ public:
 private:
 	int						LoadSettings();		//-1 error, 0 success, 1 unable to load
 	int						SaveSettings();
-	void					AttemptToAutoConnect(const TCHAR* path);
+	void					AttemptToAutoConnect(TCHAR* username, TCHAR* hostname);
+	bool					GetUserAndHostFromFilename(const TCHAR* path, TCHAR* returnUsername, TCHAR* returnHostname);
+	void					DisconnectOnInfoMismatch(TCHAR* username, TCHAR* hostname);
 
 	FTPSettings*			m_ftpSettings;
 	FTPSession*				m_ftpSession;


### PR DESCRIPTION
Allows users to save without explicitly connecting to a server. Attempts to match profile names with username parsed from filepath, and if a match is found a connection is opened and the file is uploaded. This enables users to instantly resume working remotely without considering if they're saving files on the server or not. 