### PR TITLE
libssh 0.7.7

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -73,8 +73,8 @@ DEPENDENT_LIBS = {
     'libssh': {
         'order' : 3,
         'shadow': True,
-        'url'   : 'https://www.libssh.org/files/0.8/libssh-0.8.7.tar.xz',
-        'sha1'  : '29ed6d9517ce270fee993cccb0219bd16a595bcc',
+        'url'   : 'https://www.libssh.org/files/0.7/libssh-0.7.7.tar.xz',
+        'sha1'  : '2aef0300469260566f4cfb1809dcd0d807b8e66f',
         'target': {
             'mingw-w64': {
                 'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],


### PR DESCRIPTION
- reduced build config for libssh by switching off some unused parts via libssh cmake configs
- build multithreaded

- update to libssh 0.7.7 with:
-- Fixed issues with MSVC
-- Fixed keyboard-interactive auth in server mode (regression from CVE-2018-10933)
-- Fixed gssapi auth in server mode (regression from CVE-2018-10933)
-- Fixed a memory leak with OpenSSL
- update to libssh 0.7.6 with:
-- Fixed CVE-2018-10933
-- Added support for OpenSSL 1.1
-- Added SHA256 support for ssh_get_publickey_hash()
-- Fixed config parsing
-- Fixed random memory corruption when importing pubkeys