### PR TITLE
OpenSSL 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (MINGW)
 
     target_link_libraries (NppFTP comctl32 shlwapi ssh ssl crypto z ws2_32)
 else (MINGW)
-    target_link_libraries (NppFTP comctl32 shlwapi ssh libeay32 ssleay32 zlib ws2_32)
+    target_link_libraries (NppFTP comctl32 shlwapi ssh libssl libcrypto zlib ws2_32)
 endif (MINGW)
 
 # build a CPack driven zip package

--- a/UTCP/include/ut_clnt.h
+++ b/UTCP/include/ut_clnt.h
@@ -120,7 +120,7 @@ public:
 class CUT_WSClient : public CUT_CLIENT_BASE_CLASS
 {
 public:
-	enum SSLMode {NONE, TLS, SSLv2, SSLv3, SSLv23};
+	enum SSLMode {NONE, TLSv1, TLSv11, TLSv12, TLS};
 	virtual int EnableSSL(bool enable);
 
 	virtual int SetSecurityMode(SSLMode mode);

--- a/UTCP/src/ftp_c.cpp
+++ b/UTCP/src/ftp_c.cpp
@@ -185,8 +185,8 @@ int CUT_FTPClient::FTPConnect(LPCSTR hostname,LPCSTR userName,LPCSTR password,LP
 
 	if (m_sMode != FTP) {
 		if (m_sMode == FTPS) {	//in case of implicit SSL, negotiate security version with v23
-			SetSecurityMode(CUT_FTPClient::SSLv23);
-			m_wsData.SetSecurityMode(CUT_FTPClient::SSLv23);
+			SetSecurityMode(CUT_FTPClient::TLS);
+			m_wsData.SetSecurityMode(CUT_FTPClient::TLS);
 		} else {
 			//Try TLS first, SSL later
 			SetSecurityMode(CUT_FTPClient::TLS);
@@ -3293,16 +3293,16 @@ int CUT_FTPClient::SocketOnConnected(SOCKET /*s*/, const char * /*lpszName*/){
 			}
 			else																// If the SSL succeded then set the protocol to SSL
 			{
-				SetSecurityMode(CUT_WSClient::SSLv3);
-				m_wsData.SetSecurityMode(CUT_WSClient::SSLv3);
+				SetSecurityMode(CUT_WSClient::TLS);
+				m_wsData.SetSecurityMode(CUT_WSClient::TLS);
 				rt = ConnectSSL();
 			}
 		}
 		else
 		{
-			//SSLv23 is the default starting with TLS 1.2 -> SSLV3
-			SetSecurityMode(CUT_WSClient::SSLv23);
-			m_wsData.SetSecurityMode(CUT_WSClient::SSLv23);
+			//TLS is the default starting with TLS 1.3 -> SSLV3
+			SetSecurityMode(CUT_WSClient::TLS);
+			m_wsData.SetSecurityMode(CUT_WSClient::TLS);
 			rt = ConnectSSL();
 		}
 

--- a/UTCP/src/ut_clnt.cpp
+++ b/UTCP/src/ut_clnt.cpp
@@ -638,18 +638,18 @@ int CUT_WSClient::SetSecurityMode(SSLMode mode){
 
 	m_sslMode = mode;
 	switch(mode) {
-		case TLS:
+		case TLSv1:
 			m_meth = TLSv1_client_method();
 			break;
-		case SSLv2:
-			m_meth = SSLv2_client_method();
+		case TLSv11:
+			m_meth = TLSv1_1_client_method();
 			break;
-		case SSLv3:
-			m_meth = SSLv3_client_method();
+		case TLSv12:
+			m_meth = TLSv1_2_client_method();
 			break;
-		case SSLv23:
+		case TLS:
 		default:
-			m_meth = SSLv23_client_method();
+			m_meth = TLS_client_method();
 			break;
 	}
 

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -5,30 +5,30 @@
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://www.openssl.org/source/openssl-1.0.2q.tar.gz',
-        'sha1'  : '692f5f2f1b114f8adaadaa3e7be8cce1907f38c5',
+        'url'   : 'https://www.openssl.org/source/openssl-1.1.1b.tar.gz',
+        'sha1'  : 'e9710abf5e95c48ebf47991b10cbb48c09dae102',
         'target': {
             'mingw-w64': {
                 'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s --cross-compile-prefix=%(prefix)s- no-shared no-asm mingw64',
-                    'make depend', 'make', 'make install_sw'
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s --cross-compile-prefix=%(prefix)s- no-shared no-asm mingw64',
+                    'make', 'make install_sw'
                 ]
             },
             'msvc': {
-                'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
+               'result':   ['include/openssl/ssl.h', 'lib/libssl.lib', 'lib/libcrypto.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN32 -wd4005',
-                    'ms\\do_ms.bat',
-                    'nmake /f ms\\nt.mak install'
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s no-shared no-asm no-capieng VC-WIN32 -wd4005',
+                    'nmake',
+                    'nmake install_sw'
                 ]
             },
             'msvc_x64': {
-                'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
+                'result':   ['include/openssl/ssl.h', 'lib/libssl.lib', 'lib/libcrypto.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN64A',
-                    'ms\\do_win64a.bat',
-                    'nmake /f ms\\nt.mak install'
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s no-shared no-asm no-capieng VC-WIN64A',
+                    'nmake',
+                    'nmake install_sw'
                 ]
             }
         }
@@ -92,7 +92,7 @@ DEPENDENT_LIBS = {
                 'commands': [
                     'cmake -G "NMake Makefiles" -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_BUILD_TYPE=Release \
                         "-DCMAKE_C_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" "-DCMAKE_CXX_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" \
-                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libeay32.lib \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libcrypto.lib \
                         -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'nmake install',
                     'del %(dest)s\\lib\\ssh.lib >nul',
@@ -104,7 +104,7 @@ DEPENDENT_LIBS = {
                 'commands': [
                     'cmake -G "NMake Makefiles" -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_BUILD_TYPE=Release \
                         "-DCMAKE_C_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" "-DCMAKE_CXX_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" \
-                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libeay32.lib \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libcrypto.lib \
                         -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'nmake install',
                     'del %(dest)s\\lib\\ssh.lib >nul',

--- a/build_windows_from_vs_shell
+++ b/build_windows_from_vs_shell
@@ -1,0 +1,4 @@
+set PATH=C:\Program Files\CMake\bin;C:\Users\christian\Source\Repos\npp_ftp_plain\NppFTP\Python36;C:\Users\christian\Source\Repos\npp_ftp_plain\NppFTP\Python36\Scripts;C:\Users\christian\Source\Repos\npp_ftp_plain\NppFTP\strawberry-perl-5.24.1.1-64bit-portable\perl\bin;%PATH%
+cd build
+cmake -G "Visual Studio 15 2017 Win64" -T "v141_xp" ..
+cmake --build . --config Debug


### PR DESCRIPTION
- update to new LTS branch https://www.openssl.org/source/openssl-1.1…1a.tar.gz
- changed to use TLS_client_method() as default, see https://www.openssl.org/docs/man1.1.1/man3/SSLv3_method.html