### PR TITLE
OpenSSL 1.1.1d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (MINGW)
 
     target_link_libraries (NppFTP comctl32 shlwapi ssh ssl crypto z ws2_32)
 else (MINGW)
-    target_link_libraries (NppFTP comctl32 shlwapi ssh libeay32 ssleay32 zlib ws2_32)
+    target_link_libraries (NppFTP comctl32 shlwapi ssh libssl libcrypto zlib ws2_32)
 endif (MINGW)
 
 # build a CPack driven zip package

--- a/UTCP/include/ut_clnt.h
+++ b/UTCP/include/ut_clnt.h
@@ -120,7 +120,7 @@ public:
 class CUT_WSClient : public CUT_CLIENT_BASE_CLASS
 {
 public:
-    enum SSLMode {NONE, TLS, SSLv2, SSLv3, SSLv23};
+    enum SSLMode {NONE, TLS};
     virtual int EnableSSL(bool enable);
 
     virtual int SetSecurityMode(SSLMode mode);

--- a/UTCP/src/ftp_c.cpp
+++ b/UTCP/src/ftp_c.cpp
@@ -185,8 +185,8 @@ int CUT_FTPClient::FTPConnect(LPCSTR hostname,LPCSTR userName,LPCSTR password,LP
 
     if (m_sMode != FTP) {
         if (m_sMode == FTPS) {  //in case of implicit SSL, negotiate security version with v23
-            SetSecurityMode(CUT_FTPClient::SSLv23);
-            m_wsData.SetSecurityMode(CUT_FTPClient::SSLv23);
+            SetSecurityMode(CUT_FTPClient::TLS);
+            m_wsData.SetSecurityMode(CUT_FTPClient::TLS);
         } else {
             //Try TLS first, SSL later
             SetSecurityMode(CUT_FTPClient::TLS);
@@ -3293,16 +3293,16 @@ int CUT_FTPClient::SocketOnConnected(SOCKET /*s*/, const char * /*lpszName*/){
             }
             else                                                                // If the SSL succeded then set the protocol to SSL
             {
-                SetSecurityMode(CUT_WSClient::SSLv3);
-                m_wsData.SetSecurityMode(CUT_WSClient::SSLv3);
+                SetSecurityMode(CUT_WSClient::TLS);
+                m_wsData.SetSecurityMode(CUT_WSClient::TLS);
                 rt = ConnectSSL();
             }
         }
         else
         {
-            //SSLv23 is the default starting with TLS 1.2 -> SSLV3
-            SetSecurityMode(CUT_WSClient::SSLv23);
-            m_wsData.SetSecurityMode(CUT_WSClient::SSLv23);
+            //TLS is the default starting with TLS 1.3 -> SSLV3
+            SetSecurityMode(CUT_WSClient::TLS);
+            m_wsData.SetSecurityMode(CUT_WSClient::TLS);
             rt = ConnectSSL();
         }
 

--- a/UTCP/src/ut_clnt.cpp
+++ b/UTCP/src/ut_clnt.cpp
@@ -639,17 +639,9 @@ int CUT_WSClient::SetSecurityMode(SSLMode mode){
     m_sslMode = mode;
     switch(mode) {
         case TLS:
-            m_meth = TLSv1_client_method();
-            break;
-        case SSLv2:
-            m_meth = SSLv2_client_method();
-            break;
-        case SSLv3:
-            m_meth = SSLv3_client_method();
-            break;
-        case SSLv23:
         default:
-            m_meth = SSLv23_client_method();
+            //all version specific methods are deprecated since openssl 1.1.0
+            m_meth = TLS_client_method();
             break;
     }
 

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -5,30 +5,37 @@
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://www.openssl.org/source/openssl-1.0.2t.tar.gz',
-        'sha1'  : '8ac3fd379cf8c8ef570abb51ec52a88fd526f88a',
+        'url'   : 'https://www.openssl.org/source/openssl-1.1.1d.tar.gz',
+        'sha1'  : '056057782325134b76d1931c48f2c7e6595d7ef4',
         'target': {
             'mingw-w64': {
                 'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s --cross-compile-prefix=%(prefix)s- no-shared no-asm mingw64',
-                    'make depend', 'make', 'make install_sw'
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s --cross-compile-prefix=%(prefix)s- no-asm mingw',
+                    'make', 'make install_sw'
+                ]
+            },
+            'mingw-w64_x64': {
+                'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],
+                'commands': [
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s --cross-compile-prefix=%(prefix)s- no-asm mingw64',
+                    'make', 'make install_sw'
                 ]
             },
             'msvc': {
-                'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
+                'result':   ['include/openssl/ssl.h', 'lib/libssl.lib', 'lib/libcrypto.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN32 -wd4005',
-                    'ms\\do_ms.bat',
-                    'nmake /f ms\\nt.mak install'
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s no-shared no-asm no-capieng VC-WIN32 -wd4005',
+                    'nmake',
+                    'nmake install_sw'
                 ]
             },
             'msvc_x64': {
-                'result':   ['include/openssl/ssl.h', 'lib/libeay32.lib', 'lib/ssleay32.lib'],
+                'result':   ['include/openssl/ssl.h', 'lib/libssl.lib', 'lib/libcrypto.lib'],
                 'commands': [
-                    'perl Configure --openssldir=%(dest)s no-shared no-asm VC-WIN64A',
-                    'ms\\do_win64a.bat',
-                    'nmake /f ms\\nt.mak install'
+                    'perl Configure --prefix=%(dest)s --openssldir=%(dest)s no-shared no-asm no-capieng VC-WIN64A',
+                    'nmake',
+                    'nmake install_sw'
                 ]
             }
         }
@@ -40,6 +47,14 @@ DEPENDENT_LIBS = {
         'sha1'  : 'e6d119755acdf9104d7ba236b1242696940ed6dd',
         'target': {
             'mingw-w64': {
+                'result':   ['include/zlib.h', 'include/zconf.h', 'lib/libz.a'],
+                'commands': [
+                    'make -f win32/Makefile.gcc PREFIX=%(prefix)s-',
+                    'cp zlib.h zconf.h %(dest)s/include',
+                    'cp libz.a %(dest)s/lib'
+                ]
+            },
+            'mingw-w64_x64': {
                 'result':   ['include/zlib.h', 'include/zconf.h', 'lib/libz.a'],
                 'commands': [
                     'make -f win32/Makefile.gcc PREFIX=%(prefix)s-',
@@ -81,7 +96,19 @@ DEPENDENT_LIBS = {
                 'commands': [
                     'cmake -DCMAKE_SYSTEM_NAME=Windows \
                         -DCMAKE_C_COMPILER=%(prefix)s-gcc -DCMAKE_CXX_COMPILER=%(prefix)s-g++ \
-                        "-DCMAKE_C_FLAGS=-std=c99" \
+                        "-DCMAKE_C_FLAGS=-std=c99 -lcrypt32" \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s/include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s/lib/libcrypto.a \
+                        -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
+                    'make',
+                    'make install'
+                ]
+            },
+            'mingw-w64_x64': {
+                'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],
+                'commands': [
+                    'cmake -DCMAKE_SYSTEM_NAME=Windows \
+                        -DCMAKE_C_COMPILER=%(prefix)s-gcc -DCMAKE_CXX_COMPILER=%(prefix)s-g++ \
+                        "-DCMAKE_C_FLAGS=-std=c99 -lcrypt32" \
                         -DOPENSSL_INCLUDE_DIRS=%(dest)s/include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s/lib/libcrypto.a \
                         -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'make',
@@ -93,7 +120,7 @@ DEPENDENT_LIBS = {
                 'commands': [
                     'cmake -G "NMake Makefiles" -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_BUILD_TYPE=Release \
                         "-DCMAKE_C_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" "-DCMAKE_CXX_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" \
-                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libeay32.lib \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libcrypto.lib \
                         -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'nmake install',
                     'del %(dest)s\\lib\\ssh.lib >nul',
@@ -105,7 +132,7 @@ DEPENDENT_LIBS = {
                 'commands': [
                     'cmake -G "NMake Makefiles" -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_BUILD_TYPE=Release \
                         "-DCMAKE_C_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" "-DCMAKE_CXX_FLAGS_RELEASE=/MP /MT /O2 /Ob2 /D NDEBUG" \
-                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libeay32.lib \
+                        -DOPENSSL_INCLUDE_DIRS=%(dest)s\\include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s\\lib\\libcrypto.lib \
                         -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'nmake install',
                     'del %(dest)s\\lib\\ssh.lib >nul',
@@ -195,6 +222,8 @@ def main(outdir, prefix):
 
     if(prefix == 'msvc_x64'):
         target = 'msvc_x64'
+    elif (prefix == 'x86_64-w64-mingw32'):
+        target = 'mingw-w64_x64'
     else:
         target = platform.system() == 'Windows' and 'msvc' or 'mingw-w64'
     for library in sorted(DEPENDENT_LIBS, key=lambda x: DEPENDENT_LIBS[x]['order']):


### PR DESCRIPTION
- update to new LTS branch https://www.openssl.org/source/openssl-1.1.1d.tar.gz
- changed to use TLS_client_method() as default instead of previous SSLv23_client_method(), see https://www.openssl.org/docs/man1.1.1/man3/SSLv3_method.html