### PR TITLE
update to https://www.libssh.org/files/0.9/libssh-0.9.0.tar.xz with:

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -36,7 +36,7 @@ DEPENDENT_LIBS = {
 
     'zlib': {
         'order' : 2,
-        'url'   : 'http://downloads.sourceforge.net/libpng/zlib-1.2.11.tar.gz',
+        'url'   : 'https://downloads.sourceforge.net/libpng/zlib-1.2.11.tar.gz',
         'sha1'  : 'e6d119755acdf9104d7ba236b1242696940ed6dd',
         'target': {
             'mingw-w64': {
@@ -73,14 +73,15 @@ DEPENDENT_LIBS = {
     'libssh': {
         'order' : 3,
         'shadow': True,
-        'url'   : 'https://www.libssh.org/files/0.8/libssh-0.8.7.tar.xz',
-        'sha1'  : '29ed6d9517ce270fee993cccb0219bd16a595bcc',
+        'url'   : 'https://www.libssh.org/files/0.9/libssh-0.9.0.tar.xz',
+        'sha1'  : '570bffef68af6c1211673bc9a8036c9265935b2b',
         'target': {
             'mingw-w64': {
                 'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],
                 'commands': [
                     'cmake -DCMAKE_SYSTEM_NAME=Windows \
                         -DCMAKE_C_COMPILER=%(prefix)s-gcc -DCMAKE_CXX_COMPILER=%(prefix)s-g++ \
+                        "-DCMAKE_C_FLAGS=-std=c99" \
                         -DOPENSSL_INCLUDE_DIRS=%(dest)s/include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s/lib/libcrypto.a \
                         -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'make',


### PR DESCRIPTION
We are proud to announce a new major release of the SSH library. Version 0.9.0 offers a lot of new features and bug fixes. We added support for AES-GCM encryption, Encrypt-then-MAC mode, elliptic-curve certificate support, FIPS 140-2 compatibility and many more.

We also added support for server side configuration parsing. This is mostly useful for defining ciphers, mac modes and hashes. We also improved the performance and reduced the copying of data for internal data structures.

When libssh is built against a recent version of OpenSSL we will use the new APIs for KEX, DH, KDF and signatures. This is especially required for FIPS compatibility.

With this release we also disabled blowfish support by default.

As we started to use Gitlab CI for testing with libssh 0.8.0 we extended our testsuite with server tests which also revealed some bugs. We’ve added csbuild to get more static code analysis to detect issues before we commit them to the upstream repository.

Thanks to all contributors who made this release possible!

If you are new to libssh you should read our tutorial how to get started.
Please join our mailing list or visit our irc channel if you have
questions.

You can download libssh-0.9.0 here.
ChangeLog

    Added support for AES-GCM
    Added improved rekeying support
    Added performance improvements
    Disabled blowfish support by default
    Fixed several ssh config parsing issues
    Added support for DH Group Exchange KEX
    Added support for Encrypt-then-MAC mode
    Added support for parsing server side configuration file
    Added support for ECDSA/Ed25519 certificates
    Added FIPS 140-2 compatibility
    Improved known_hosts parsing
    Improved documentation
    Improved OpenSSL API usage for KEX, DH, KDF and signatures

Code Stats

Between version 0.8.0 and 0.9.0 the libssh did:

    910 commits
    265 files changed, 41328 insertions(+), 14319 deletions(-)