### PR TITLE
updated to libssh-0-9-1

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -88,15 +88,15 @@ DEPENDENT_LIBS = {
     'libssh': {
         'order' : 3,
         'shadow': True,
-        'url'   : 'https://git.libssh.org/projects/libssh.git/snapshot/libssh-0.9.0.tar.xz',
-        'sha1'  : '4e713745e1c8bbe39f8480669661101853446825',
+        'url'   : 'https://git.libssh.org/projects/libssh.git/snapshot/libssh-0.9.1.tar.xz',
+        'sha1'  : '0c3629c04a69cc2be9312788d108f66dfa474343',
         'target': {
             'mingw-w64': {
                 'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],
                 'commands': [
                     'cmake -DCMAKE_SYSTEM_NAME=Windows \
                         -DCMAKE_C_COMPILER=%(prefix)s-gcc -DCMAKE_CXX_COMPILER=%(prefix)s-g++ \
-                        "-DCMAKE_C_FLAGS=-std=c99 -lcrypt32" \
+                        "-lcrypt32" \
                         -DOPENSSL_INCLUDE_DIRS=%(dest)s/include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s/lib/libcrypto.a \
                         -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'make',
@@ -108,7 +108,7 @@ DEPENDENT_LIBS = {
                 'commands': [
                     'cmake -DCMAKE_SYSTEM_NAME=Windows \
                         -DCMAKE_C_COMPILER=%(prefix)s-gcc -DCMAKE_CXX_COMPILER=%(prefix)s-g++ \
-                        "-DCMAKE_C_FLAGS=-std=c99 -lcrypt32" \
+                        "-lcrypt32" \
                         -DOPENSSL_INCLUDE_DIRS=%(dest)s/include -DOPENSSL_CRYPTO_LIBRARY=%(dest)s/lib/libcrypto.a \
                         -DWITH_STATIC_LIB=ON -DWITH_EXAMPLES=OFF -DWITH_SERVER=OFF -DCMAKE_INSTALL_PREFIX=%(dest)s -DCMAKE_PREFIX_PATH=%(dest)s %(src)s',
                     'make',


### PR DESCRIPTION
, see https://www.libssh.org/2019/10/25/libssh-0-9-1/

The libssh team is proud to announce the first bugfix release of libssh as version 0.9.1. It fixes bugs we discovered since the last release. Thanks to all contributors!

There are two things new and this is that we use X22919 and Ed25519 from OpenSSL if it provides them.

If you are new to libssh you should read our tutorial how to get started. Please join our mailing list or visit our IRC channel if you have questions.

You can download libssh here.
Changelog

    Added support for Ed25519 via OpenSSL
    Added support for X25519 via OpenSSL
    Added support for localuser in Match keyword
    Fixed Match keyword to be case sensitive
    Fixed compilation with LibreSSL
    Fixed error report of channel open (T75)
    Fixed sftp documentation (T137)
    Fixed known_hosts parsing (T156)
    Fixed build issue with MinGW (T157)
    Fixed build with gcc 9 (T164)
    Fixed deprecation issues (T165)
    Fixed known_hosts directory creation (T166) Fixed some issues with the connector API