### PR TITLE
bump version to 0.30.3, include libssh 0.9.3 (security fix)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.30.2.{build}
+version: 0.30.3.{build}
 image: Visual Studio 2017
 
 

--- a/src/Windows/symbols.h
+++ b/src/Windows/symbols.h
@@ -1,2 +1,2 @@
-#define IDT_VERSION_TEXT	"0.30.2 Unicode"
-#define IDT_VERSION_NUM		0,30,2,0
+#define IDT_VERSION_TEXT	"0.30.3 Unicode"
+#define IDT_VERSION_NUM		0,30,3,0


### PR DESCRIPTION
use in the 0.30.x also the libssh 0.9.3 (security fix)