### PR TITLE
update to libssh 0.11.0

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -88,8 +88,8 @@ DEPENDENT_LIBS = {
     'libssh': {
         'order' : 3,
         'shadow': True,
-        'url'   : 'https://www.libssh.org/files/0.10/libssh-0.10.6.tar.xz',
-        'sha1'  : 'e8fb3b4750db11d2483cac4b5f046e301c09b72f',
+        'url'   : 'https://www.libssh.org/files/0.11/libssh-0.11.0.tar.xz',
+        'sha1'  : 'b6d355f9c1b6159c0716664660d9ec6182b39438',
         'target': {
             'mingw-w64': {
                 'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],


### PR DESCRIPTION
Changelog:

Deprecations and Removals:

    Dropped support for DSA
    Deprecated Blowfish cipher (will be removed in next release)
    Deprecated SSH_BIND_OPTIONS_{RSA,ECDSA}KEY in favor of generic HOSTKEY
    Removed the usage of deprecated OpenSSL APIs (Note: Minimum supported OpenSSL version is 1.1.1)
    Disabled preauth compression (zlib) by default
    Support for pkcs#11 engines are deprecated, pkcs11-provider is used instead
    Deprecation of old partial async SFTP API
    libgcrypt cryptographic backend is deprecated
    Deprecation of knownhosts hashing

SFTP Improvements:

    Added support for async SFTP IO
    Added support for sftp_limits() and applied capping to SFTP read/write operations accordingly
    Added sftp_home_directory() API support for sftp extension “home-directory”
    Added sftp_lsetstat() API for lsetstat extensions
    Added sftp_expand_path() to canonicalize path using expand-path@openssh.com extension
    Implemented stat and realpath in sftpserver
    Added sftp_readlink() API to support hardlink@openssh.com
    New extensible callback based SFTP server
    Introduced the posix-rename@openssh.com extension

New functions and features:

    Added support for PKCS #11 provider for OpenSSL 3.0
    Added testing for GSSAPI Authentication
    Implemented proxy jump using libssh
    Recategorized loglevels to show fatal errors and alignment with OpenSSH log levels
    Added ssh_channel_request_pty_size_modes() API to set terminal modes for PTYs
    Added function to check username syntax
    Added support to check all keys in authorized_keys instead of one in example server implementation
    Handled hostkey similar to OpenSSH
    Added ssh_session_socket_close() API in order to not close socket passed through options on error conditions
    Added option SSH_BIND_OPTIONS_IMPORT_KEY_STR to read user-supplied key string in ssh_bind_options_set()
    Improved log handling around ssh_set_callbacks
    Added ssh_set_error_invalid in ssh_options_set()
    Prevented signature blob to start with 1 bit in libgcrypt
    Added support to unbreak key comparison of Ed25519 keys imported from PEM or OpenSSH container
    Added support to calculate missing CRT parameters when building RSA key
    Added ssh_pki_export_privkey_base64_format() and ssh_pki_export_privkey_file_format() to support exporting keys in different formats (PEM, OpenSSH)
    Added support to compare certificates and handle automatic certificate authentication
    Added support to make compile-commands generation conditional
    Built fuzzers for normal testing
    Avoided passing other events to callbacks when called recursively
    Added control master and path options
    Refactored channel_rcv_data, check for errors and report more useful errors
    Added support to connect to other host addresses than just the first one
    Terminated the server properly when the MaxAuthTries is reached
    Added support for no-more-sessions@openssh.com request in both client and server
    Added callback to support forwarded-tcpip requests
    Bumped minimal CMake version to 3.12
    Added support for MBedTLS 3.6.x
    Added support for +,-,^ modifiers in front of algorithm lists in options
    Added callbacks for channel open response, and channel request response
    Replaced chroot() from chroot_wrapper internal library with chroot() from priv_wrapper package
    Added a placeholder for non-expanded identities
    Improved handling of channel transfer window sizes
