### PR TITLE
Openssl 35

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -5,8 +5,8 @@
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://github.com/openssl/openssl/releases/download/openssl-3.5.0-beta1/openssl-3.5.0-beta1.tar.gz',
-        'sha256'  : '8f0be61fae28c9f83dec382587b0d4103eddbdaa6c20f194da198e8f76d40fbc',
+        'url'   : 'https://github.com/openssl/openssl/releases/download/openssl-3.5.0/openssl-3.5.0.tar.gz',
+        'sha256'  : '344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0',
         'target': {
             'mingw-w64': {
                 'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],

--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -5,8 +5,8 @@
 DEPENDENT_LIBS = {
     'openssl': {
         'order' : 1,
-        'url'   : 'https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz',
-        'sha256'  : '002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3',
+        'url'   : 'https://github.com/openssl/openssl/releases/download/openssl-3.5.0-beta1/openssl-3.5.0-beta1.tar.gz',
+        'sha256'  : '8f0be61fae28c9f83dec382587b0d4103eddbdaa6c20f194da198e8f76d40fbc',
         'target': {
             'mingw-w64': {
                 'result':   ['include/openssl/ssl.h', 'lib/libssl.a', 'lib/libcrypto.a'],


### PR DESCRIPTION
https://github.com/openssl/openssl/releases/download/openssl-3.5.0/openssl-3.5.0.tar.gz

See https://github.com/openssl/openssl/releases/tag/openssl-3.5.0 for changes