### PR TITLE
libssh 0.12.0

### DIFF
--- a/build_3rdparty.py
+++ b/build_3rdparty.py
@@ -88,8 +88,8 @@ DEPENDENT_LIBS = {
     'libssh': {
         'order' : 3,
         'shadow': True,
-        'url'   : 'https://www.libssh.org/files/0.11/libssh-0.11.4.tar.xz',
-        'sha256'  : '002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701',
+        'url'   : 'https://www.libssh.org/files/0.12/libssh-0.12.0.tar.xz',
+        'sha256'  : '1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121',
         'target': {
             'mingw-w64': {
                 'result':   ['include/libssh/libssh.h', 'lib/libssh.a'],


### PR DESCRIPTION
ChangeLog for libssh 0.12.0:
Security:

    [CVE-2025-14821](http://www.libssh.org/security/advisories/CVE-2025-14821.txt): libssh loads configuration files from the C:\etc directory
    on Windows
    [CVE-2026-0964](http://www.libssh.org/security/advisories/CVE-2026-0964.txt): SCP Protocol Path Traversal in ssh_scp_pull_request()
    [CVE-2026-0965](http://www.libssh.org/security/advisories/CVE-2026-0965.txt): Possible Denial of Service when parsing unexpected
    configuration files
    [CVE-2026-0966](http://www.libssh.org/security/advisories/CVE-2026-0966.txt): Buffer underflow in ssh_get_hexa() on invalid input
    [CVE-2026-0967](http://www.libssh.org/security/advisories/CVE-2026-0967.txt): Specially crafted patterns could cause DoS
    [CVE-2026-0968](http://www.libssh.org/security/advisories/CVE-2026-0968.txt): OOB Read in sftp_parse_longname()
    [libssh-2026-sftp-extensions](http://www.libssh.org/security/advisories/libssh-2026-sftp-extensions.txt): Read buffer overrun when handling SFTP
    extensions

Deprecations and removals:

    Bumped minimal RSA key size to 1024 bits

New functionality:

    Add support for hybrid key exchange mechanisms using Quantum Resistant cryptography for all backends. These are now preferred:
        sntrup761x25519-sha512, sntrup761x25519-sha512@openssh.com
        mlkem768nistp256-sha256
        mlkem768x25519-sha256
        mlkem1024nistp384-sha384 (only OpenSSL 3.5+ and libgcrypt)
    New cmake option WITH_HERMETIC_USR
    Added support for Ed25519 keys through PKCS#11
    Support for host-bound public key authentication
    (publickey-hostbound-v00@openssh.com)
    Use curve25519 implementation from mbedTLS and libgcrypt
    New functions for signing arbitrary data (commits) with SSH keys
        sshsig_sign()
        sshsig_verify()
    Support for FIDO/U2F keys (internal implementation using libfido2)
        Compatible with OpenSSH: should work out of the box
        Extensible with callbacks
    Add support for GSSAPI Key Exchange (RFC 4462, RFC 8732)
    Add support for new configuratation options (client and server):
        RequiredRsaSize
        AddressFamily (client)
        GSSAPIKeyExchange
        GSSAPIKexAlgorithms
    New option to get list of configured identities (SSH_OPTIONS_NEXT_IDENTITY)
    More OpenSSH compatible percent expansion characters
    Add new server auth_kbdint_function() callback
    New PKI Context structure for key operations
    Stability and compatibility improvements of ProxyJump

SFTP

    Prevent failures when SFTP status message does not contain error message
    Fix possible timeouts while waiting for SFTP messages
    Support for users-groups-by-id@openssh.com extension in client
    Support for SSH_FXF_TRUNC in server